### PR TITLE
fix(CI/CD): allow publishing badges on gh-pages branch

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Publish to gh-pages
         run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
           git fetch origin gh-pages || true
           git checkout --orphan gh-pages
           git rm -rf .


### PR DESCRIPTION
## 📋 Description

This pull request makes a small but important update to the GitHub Actions workflow for publishing coverage reports. It configures the Git user name and email before publishing to the `gh-pages` branch, which helps ensure that commits made by the workflow are properly attributed.

- Workflow configuration:
  * [`.github/workflows/publish-coverage.yml`](diffhunk://#diff-be2c9642e19f3f4fefec7492de1299cb4a52276db4ebf2e4ff7c56c562532549R37-R39): Added steps to set the Git user name and email to "github-actions[bot]" before publishing to `gh-pages`.

---

## 🔗 Related Issue

Not defined

---

## 🚀 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Tooling / Build system

---

## 🧪 Testing

How have you tested your changes?

- [ ] Unit tests
- [x] Manual testing (describe below)
- [ ] Not tested (explain why)

**Details**: Pipeline run

---

## ⚠️ Pre-Alpha Considerations

- [x] I am aware that K2D APIs are unstable
- [x] I kept the change minimal and focused
- [x] I avoided unnecessary public API exposure

---

## 📝 Checklist

- [x] Code follows the project style
- [x] New logic is documented (if applicable)
- [x] No existing tests are broken
- [x] I am willing to iterate based on feedback