### PR TITLE
chore(repo): rename repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/sgalluz/K2D/discussions
+    url: https://github.com/sgalluz/k2d/discussions
     about: Ask questions or discuss ideas about K2D here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ Basic requirements:
 
 Clone the repository:
 ```bash
-git clone https://github.com/sgalluz/K2D.git
-cd K2D
+git clone https://github.com/sgalluz/k2d.git
+cd k2d
 ```
 
 Run the sample project:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <img src="https://img.shields.io/badge/Platform-Desktop-orange?logo=linux&logoColor=white" alt="Platform Desktop">
   <img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="License Apache 2.0">
   <img src="https://img.shields.io/badge/Status-Pre--Alpha-red" alt="Status Pre-Alpha">
-  <img src="https://codecov.io/github/sgalluz/K2D/graph/badge.svg?token=R00L4MD9N3" alt="Coverage"/>
+  <img src="https://codecov.io/github/sgalluz/k2d/graph/badge.svg?token=R00L4MD9N3" alt="Coverage"/>
 </div>
 
 ---

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,3 @@
-rootProject.name = "K2D"
+rootProject.name = "k2d"
 include(":engine")
 include(":sample")


### PR DESCRIPTION
## 📋 Description
This pull request standardizes the project name and repository references from "K2D" to "k2d" across documentation, configuration, and build files. The updates ensure consistency in naming conventions and correct repository links throughout the project.

**Repository references and documentation:**
* Updated all repository URLs and references in `.github/ISSUE_TEMPLATE/config.yml`, `CONTRIBUTING.md`, and `README.md` to use the lowercase `k2d` instead of `K2D`. [[1]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L4-R4) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L60-R61) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21)

**Build configuration:**
* Changed the root project name in `settings.gradle.kts` from `K2D` to `k2d` for consistency with the repository name.

---

## 🔗 Related Issue
Not available

---

## 🚀 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Tooling / Build system

---

## 🧪 Testing
How have you tested your changes?
- [ ] Unit tests
- [ ] Manual testing (describe below)
- [x] Not tested (explain why)

**Details**: Not applicable

---

## ⚠️ Pre-Alpha Considerations
- [x] I am aware that K2D APIs are unstable
- [x] I kept the change minimal and focused
- [x] I avoided unnecessary public API exposure

---

## 📝 Checklist
- [x] Code follows the project style
- [x] New logic is documented (if applicable)
- [x] No existing tests are broken
- [x] I am willing to iterate based on feedback