### PR TITLE
ci(publish): add proper permissions to publish step

### DIFF
--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -28,6 +28,9 @@ jobs:
   publish:
     needs: test
     uses: ./.github/workflows/gradle-checks.yml
+    permissions:
+      contents: read
+      packages: write
     with:
       job-name: "Publish Engine SNAPSHOT"
       task: "publish"


### PR DESCRIPTION
## 📋 Description
This pull request makes a minor update to the GitHub Actions workflow configuration. The change adds explicit permissions for reading repository contents and writing to packages in the `publish` job.

---

## 🔗 Related Issue

Related to #20 

---

## 🚀 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Tooling / Build system

---

## 🧪 Testing

How have you tested your changes?

- [ ] Unit tests
- [ ] Manual testing (describe below)
- [x] Not tested (explain why)

**Details**: Not needed

---

## ⚠️ Pre-Alpha Considerations

- [x] I am aware that K2D APIs are unstable
- [x] I kept the change minimal and focused
- [x] I avoided unnecessary public API exposure

---

## 📝 Checklist

- [x] Code follows the project style
- [x] New logic is documented (if applicable)
- [x] No existing tests are broken
- [x] I am willing to iterate based on feedback