### PR TITLE
fix(snapshot): setup GH token for publish job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,18 +7,12 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/gradle-checks.yml
-    permissions:
-      contents: read
-      packages: write
     with:
       job-name: "Assemble Engine"
       task: "assemble"
 
   lint:
     uses: ./.github/workflows/gradle-checks.yml
-    permissions:
-      contents: read
-      packages: write
     with:
       job-name: "Lint Engine"
       task: "ktlintCheck"
@@ -28,7 +22,6 @@ jobs:
     uses: ./.github/workflows/gradle-checks.yml
     permissions:
       contents: read
-      packages: write
       pull-requests: write
     with:
       job-name: "Test & Coverage Engine"


### PR DESCRIPTION
## 📋 Description

This pull request makes minor adjustments to the GitHub Actions workflow for Gradle checks. The main changes involve the removal of unnecessary permissions and the addition of environment variables for the Gradle task execution.

Workflow configuration updates:

* Removed the `permissions` block from the `gradle-task` job, as it was not necessary for the workflow.
* Added `GITHUB_ACTOR` and `GITHUB_TOKEN` as environment variables for the Gradle task step to improve authentication and context during workflow execution.

---

## 🔗 Related Issue

Related to #20 

---

## 🚀 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Tooling / Build system

---

## 🧪 Testing

How have you tested your changes?

- [ ] Unit tests
- [x] Manual testing (describe below)
- [ ] Not tested (explain why)

**Details**: Describe how you tested the changes.

---

## ⚠️ Pre-Alpha Considerations

- [x] I am aware that K2D APIs are unstable
- [x] I kept the change minimal and focused
- [x] I avoided unnecessary public API exposure

---

## 📝 Checklist

- [x] Code follows the project style
- [x] New logic is documented (if applicable)
- [x] No existing tests are broken
- [x] I am willing to iterate based on feedback