### PR TITLE
ci(dependabot-auto-merge): fix merge strategy

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Approve and enable auto-merge
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📋 Description

This pull request updates the auto-merge behavior for Dependabot pull requests in the GitHub Actions workflow. Instead of merging with the default "merge" strategy, it now uses the "squash" strategy, which will create a single commit from all changes in the pull request.

Workflow configuration update:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L22-R22): Changed the auto-merge command to use the `--squash` option instead of `--merge`, ensuring that merged Dependabot PRs are squashed into a single commit.

---

## 🔗 Related Issue

Not available.

---

## 🚀 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Tooling / Build system

---

## 🧪 Testing

How have you tested your changes?

- [ ] Unit tests
- [ ] Manual testing (describe below)
- [x] Not tested (explain why)

**Details**: Not available.

---

## ⚠️ Pre-Alpha Considerations

- [x] I am aware that K2D APIs are unstable
- [x] I kept the change minimal and focused
- [x] I avoided unnecessary public API exposure

---

## 📝 Checklist

- [x] Code follows the project style
- [x] New logic is documented (if applicable)
- [x] No existing tests are broken
- [x] I am willing to iterate based on feedback